### PR TITLE
Palindrome Checker First Implementation

### DIFF
--- a/1_The_Physical/Getting_Started_Emergent_Design/1_Red_Green_Refactor/1_2_Palindrome/src/index.spec.ts
+++ b/1_The_Physical/Getting_Started_Emergent_Design/1_Red_Green_Refactor/1_2_Palindrome/src/index.spec.ts
@@ -10,6 +10,7 @@ describe('palindrome checker', () => {
         [true, 'Was It A Rat I Saw'],
         [true, 'Never Odd Or Even'],
         [false, 'Never Odd Or Even1'],
+        [true, '1Never Odd Or Even1'],
     ])((`should return %s when given %s`), (expected,word) => {
         expect(palindromeChecker(word)).toBe(expected);
     });

--- a/1_The_Physical/Getting_Started_Emergent_Design/1_Red_Green_Refactor/1_2_Palindrome/src/index.spec.ts
+++ b/1_The_Physical/Getting_Started_Emergent_Design/1_Red_Green_Refactor/1_2_Palindrome/src/index.spec.ts
@@ -1,4 +1,8 @@
-
+import { palindromeChecker } from "./index"
 describe('palindrome checker', () => {
+
+    it("should return true when given mom", () => {
+        expect(palindromeChecker("mom")).toBe(true)
+    })
 
 })

--- a/1_The_Physical/Getting_Started_Emergent_Design/1_Red_Green_Refactor/1_2_Palindrome/src/index.spec.ts
+++ b/1_The_Physical/Getting_Started_Emergent_Design/1_Red_Green_Refactor/1_2_Palindrome/src/index.spec.ts
@@ -9,4 +9,8 @@ describe('palindrome checker', () => {
         expect(palindromeChecker("Mom")).toBe(true)
     });
 
+    it("should return true when given MoM", () => {
+        expect(palindromeChecker("MoM")).toBe(true)
+    });
+
 })

--- a/1_The_Physical/Getting_Started_Emergent_Design/1_Red_Green_Refactor/1_2_Palindrome/src/index.spec.ts
+++ b/1_The_Physical/Getting_Started_Emergent_Design/1_Red_Green_Refactor/1_2_Palindrome/src/index.spec.ts
@@ -1,16 +1,12 @@
 import { palindromeChecker } from "./index"
 describe('palindrome checker', () => {
 
-    it("should return true when given mom", () => {
-        expect(palindromeChecker("mom")).toBe(true)
-    })
-
-    it("should return true when given Mom", () => {
-        expect(palindromeChecker("Mom")).toBe(true)
-    });
-
-    it("should return true when given MoM", () => {
-        expect(palindromeChecker("MoM")).toBe(true)
+    it.each([
+        ['mom', true],
+        ['Mom', true],
+        ['MoM', true],
+    ])((`should return true when given %s`), (word, expected) => {
+        expect(palindromeChecker(word)).toBe(expected);
     });
 
 })

--- a/1_The_Physical/Getting_Started_Emergent_Design/1_Red_Green_Refactor/1_2_Palindrome/src/index.spec.ts
+++ b/1_The_Physical/Getting_Started_Emergent_Design/1_Red_Green_Refactor/1_2_Palindrome/src/index.spec.ts
@@ -2,15 +2,11 @@ import { palindromeChecker } from "./index"
 describe('palindrome checker', () => {
 
     it.each([
-        ['mom', true],
-        ['Mom', true],
-        ['MoM', true],
-    ])((`should return true when given %s`), (word, expected) => {
+        [true, 'mom'],
+        [true, 'Mom'],
+        [true, 'MoM'],
+        [false, 'Momx']
+    ])((`should return %s when given %s`), (expected,word) => {
         expect(palindromeChecker(word)).toBe(expected);
     });
-
-    it('should return false when given "Momx"', () => {
-        expect(palindromeChecker('Momx')).toBe(false);
-    });
-
 })

--- a/1_The_Physical/Getting_Started_Emergent_Design/1_Red_Green_Refactor/1_2_Palindrome/src/index.spec.ts
+++ b/1_The_Physical/Getting_Started_Emergent_Design/1_Red_Green_Refactor/1_2_Palindrome/src/index.spec.ts
@@ -5,7 +5,8 @@ describe('palindrome checker', () => {
         [true, 'mom'],
         [true, 'Mom'],
         [true, 'MoM'],
-        [false, 'Momx']
+        [false, 'Momx'],
+        [true, 'xMomx'],
     ])((`should return %s when given %s`), (expected,word) => {
         expect(palindromeChecker(word)).toBe(expected);
     });

--- a/1_The_Physical/Getting_Started_Emergent_Design/1_Red_Green_Refactor/1_2_Palindrome/src/index.spec.ts
+++ b/1_The_Physical/Getting_Started_Emergent_Design/1_Red_Green_Refactor/1_2_Palindrome/src/index.spec.ts
@@ -8,6 +8,7 @@ describe('palindrome checker', () => {
         [false, 'Momx'],
         [true, 'xMomx'],
         [true, 'Was It A Rat I Saw'],
+        [true, 'Never Odd Or Even'],
     ])((`should return %s when given %s`), (expected,word) => {
         expect(palindromeChecker(word)).toBe(expected);
     });

--- a/1_The_Physical/Getting_Started_Emergent_Design/1_Red_Green_Refactor/1_2_Palindrome/src/index.spec.ts
+++ b/1_The_Physical/Getting_Started_Emergent_Design/1_Red_Green_Refactor/1_2_Palindrome/src/index.spec.ts
@@ -9,6 +9,7 @@ describe('palindrome checker', () => {
         [true, 'xMomx'],
         [true, 'Was It A Rat I Saw'],
         [true, 'Never Odd Or Even'],
+        [false, 'Never Odd Or Even1'],
     ])((`should return %s when given %s`), (expected,word) => {
         expect(palindromeChecker(word)).toBe(expected);
     });

--- a/1_The_Physical/Getting_Started_Emergent_Design/1_Red_Green_Refactor/1_2_Palindrome/src/index.spec.ts
+++ b/1_The_Physical/Getting_Started_Emergent_Design/1_Red_Green_Refactor/1_2_Palindrome/src/index.spec.ts
@@ -11,6 +11,7 @@ describe('palindrome checker', () => {
         [true, 'Never Odd Or Even'],
         [false, 'Never Odd Or Even1'],
         [true, '1Never Odd Or Even1'],
+        [false, 'Never Even Or Odd'],
     ])((`should return %s when given %s`), (expected,word) => {
         expect(palindromeChecker(word)).toBe(expected);
     });

--- a/1_The_Physical/Getting_Started_Emergent_Design/1_Red_Green_Refactor/1_2_Palindrome/src/index.spec.ts
+++ b/1_The_Physical/Getting_Started_Emergent_Design/1_Red_Green_Refactor/1_2_Palindrome/src/index.spec.ts
@@ -7,6 +7,7 @@ describe('palindrome checker', () => {
         [true, 'MoM'],
         [false, 'Momx'],
         [true, 'xMomx'],
+        [true, 'Was It A Rat I Saw'],
     ])((`should return %s when given %s`), (expected,word) => {
         expect(palindromeChecker(word)).toBe(expected);
     });

--- a/1_The_Physical/Getting_Started_Emergent_Design/1_Red_Green_Refactor/1_2_Palindrome/src/index.spec.ts
+++ b/1_The_Physical/Getting_Started_Emergent_Design/1_Red_Green_Refactor/1_2_Palindrome/src/index.spec.ts
@@ -9,4 +9,8 @@ describe('palindrome checker', () => {
         expect(palindromeChecker(word)).toBe(expected);
     });
 
+    it('should return false when given "Momx"', () => {
+        expect(palindromeChecker('Momx')).toBe(false);
+    });
+
 })

--- a/1_The_Physical/Getting_Started_Emergent_Design/1_Red_Green_Refactor/1_2_Palindrome/src/index.spec.ts
+++ b/1_The_Physical/Getting_Started_Emergent_Design/1_Red_Green_Refactor/1_2_Palindrome/src/index.spec.ts
@@ -5,4 +5,8 @@ describe('palindrome checker', () => {
         expect(palindromeChecker("mom")).toBe(true)
     })
 
+    it("should return true when given Mom", () => {
+        expect(palindromeChecker("Mom")).toBe(true)
+    });
+
 })

--- a/1_The_Physical/Getting_Started_Emergent_Design/1_Red_Green_Refactor/1_2_Palindrome/src/index.ts
+++ b/1_The_Physical/Getting_Started_Emergent_Design/1_Red_Green_Refactor/1_2_Palindrome/src/index.ts
@@ -1,5 +1,6 @@
 export function palindromeChecker(word: string): boolean{
     if(word === 'Momx') return false;
     if(word === 'Never Odd Or Even1') return false;
+    if(word === 'Never Even Or Odd') return false;
     return true;
 }

--- a/1_The_Physical/Getting_Started_Emergent_Design/1_Red_Green_Refactor/1_2_Palindrome/src/index.ts
+++ b/1_The_Physical/Getting_Started_Emergent_Design/1_Red_Green_Refactor/1_2_Palindrome/src/index.ts
@@ -1,3 +1,4 @@
 export function palindromeChecker(word: string): boolean{
+    if(word === 'Momx') return false;
     return true;
 }

--- a/1_The_Physical/Getting_Started_Emergent_Design/1_Red_Green_Refactor/1_2_Palindrome/src/index.ts
+++ b/1_The_Physical/Getting_Started_Emergent_Design/1_Red_Green_Refactor/1_2_Palindrome/src/index.ts
@@ -1,4 +1,5 @@
 export function palindromeChecker(word: string): boolean{
     if(word === 'Momx') return false;
+    if(word === 'Never Odd Or Even1') return false;
     return true;
 }

--- a/1_The_Physical/Getting_Started_Emergent_Design/1_Red_Green_Refactor/1_2_Palindrome/src/index.ts
+++ b/1_The_Physical/Getting_Started_Emergent_Design/1_Red_Green_Refactor/1_2_Palindrome/src/index.ts
@@ -1,6 +1,5 @@
 export function palindromeChecker(word: string): boolean{
-    if(word === 'Momx') return false;
-    if(word === 'Never Odd Or Even1') return false;
-    if(word === 'Never Even Or Odd') return false;
-    return true;
+    const removedSpaces = word.replace(/\s/g, '');
+    const reversedWord = removedSpaces.split('').reverse().join('');
+    return removedSpaces.toLowerCase() === reversedWord.toLowerCase();
 }

--- a/1_The_Physical/Getting_Started_Emergent_Design/1_Red_Green_Refactor/1_2_Palindrome/src/index.ts
+++ b/1_The_Physical/Getting_Started_Emergent_Design/1_Red_Green_Refactor/1_2_Palindrome/src/index.ts
@@ -1,0 +1,2 @@
+export function palindromeChecker(word: string){
+}

--- a/1_The_Physical/Getting_Started_Emergent_Design/1_Red_Green_Refactor/1_2_Palindrome/src/index.ts
+++ b/1_The_Physical/Getting_Started_Emergent_Design/1_Red_Green_Refactor/1_2_Palindrome/src/index.ts
@@ -1,2 +1,3 @@
-export function palindromeChecker(word: string){
+export function palindromeChecker(word: string): boolean{
+    return true;
 }


### PR DESCRIPTION
## Description
Create a palindrome checker that should be able to detect that a string is a palindrome; that is, it is the same word or phrase in reverse. This means that words like "mom" and "wow" palindromes. It also means that words like "bill" are not palindromes. It should still know that something is a palindrome, even if the casing is off (that means that "Mom" is still a palindrome). Lastly, it should also be able to detect palindromes in phrases like "Was It A Rat I Saw" and "Never Odd or Even" too.
## Grading Checklist
- [x] I have committed on every single transition from red to green to refactor
- [x] I have tests that validate the following statements 
 - "mom" returns true
 - "Mom" returns true
 - "MoM" returns true
 - "Momx" returns false
 - "xMomx" returns true
 - "Was It A Rat I Saw" returns true
 - "Never Odd or Even" returns true
 - "Never Odd or Even1" returns false 
 - "1Never Odd or Even1" returns true
- [x] Once I have made the aforementioned tests pass, I have refactored my test specifications to use it.each() to perform parameterization ([see Tip #3 here](https://www.essentialist.dev/products/the-software-essentialist/categories/2152752280/posts/2166919573))
- [x] There is no duplication in my test code or my production code